### PR TITLE
SQLAlchemy 1.4 beta compatibility

### DIFF
--- a/sqlbag/__init__.py
+++ b/sqlbag/__init__.py
@@ -28,6 +28,7 @@ from .sqla import (
     raw_connection,
     get_raw_autocommit_connection,
     copy_url,
+    alter_url,
     connection_from_s_or_c,
     C,
 )  # noqa

--- a/sqlbag/createdrop.py
+++ b/sqlbag/createdrop.py
@@ -16,13 +16,13 @@ from sqlbag import quoted_identifier
 from .sqla import (
     admin_db_connection,
     connection_from_s_or_c,
-    copy_url,
+    make_url,
     kill_other_connections,
 )
 
 
 def database_exists(db_url, test_can_select=False):
-    url = copy_url(db_url)
+    url = make_url(db_url)
     name = url.database
     db_type = url.get_dialect().name
 
@@ -50,7 +50,7 @@ def can_select(url):
 def _database_exists(session_or_connection, name):
     c = connection_from_s_or_c(session_or_connection)
     e = copy.copy(c.engine)
-    url = copy_url(e.url)
+    url = make_url(e.url)
     dbtype = url.get_dialect().name
 
     if dbtype == "postgresql":
@@ -76,7 +76,7 @@ def _database_exists(session_or_connection, name):
 
 
 def create_database(db_url, template=None, wipe_if_existing=False):
-    target_url = copy_url(db_url)
+    target_url = make_url(db_url)
     dbtype = target_url.get_dialect().name
 
     if wipe_if_existing:
@@ -107,7 +107,7 @@ def create_database(db_url, template=None, wipe_if_existing=False):
 
 
 def drop_database(db_url):
-    url = copy_url(db_url)
+    url = make_url(db_url)
 
     dbtype = url.get_dialect().name
     name = url.database

--- a/sqlbag/sqla.py
+++ b/sqlbag/sqla.py
@@ -314,7 +314,7 @@ def kill_other_connections(s_or_c, dbname=None, hardkill=False):
 
             try:
                 c.execute(kill, pid=x.process_id)
-            except sqlalchemy.exc.InternalError as e:  # pragma: no cover
+            except DB_ERROR_TUPLE as e:  # pragma: no cover
                 code, message = e.orig.args
                 if "Unknown thread id" in message:
                     pass

--- a/sqlbag/sqla.py
+++ b/sqlbag/sqla.py
@@ -5,7 +5,9 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import copy
 import getpass
 from contextlib import contextmanager
+from packaging import version
 
+import sqlalchemy
 import sqlalchemy.engine.url
 import sqlalchemy.exc
 import sqlalchemy.orm
@@ -29,6 +31,8 @@ DB_ERROR_TUPLE = (
 
 SCOPED_SESSION_MAKERS = {}
 
+SQLA14 = version.parse(sqlalchemy.__version__) >= version.parse('1.4.0b1')
+
 
 try:
     import secrets
@@ -36,7 +40,6 @@ try:
 except ImportError:
     import random
     scopefunc = random.random
-
 
 
 def copy_url(db_url):
@@ -50,6 +53,25 @@ def copy_url(db_url):
     """
     return copy.copy(make_url(db_url))
 
+
+def alter_url(db_url, **kwargs):
+    """
+    Args:
+        db_url: Already existing SQLAlchemy :class:`URL`, or URL string.
+        **kwargs: Attributes to modify
+    Returns:
+        A brand new SQLAlchemy :class:`URL`.
+
+    Return a copy of a SQLALchemy :class:`URL` with some modifications.
+    """
+    db_url = make_url(db_url)
+    if SQLA14:
+        return db_url.set(**kwargs)
+    else:
+        db_url = copy.copy(db_url)
+        for k, v in kwargs.items():
+            setattr(db_url, k, v)
+        return db_url
 
 def connection_from_s_or_c(s_or_c):
     """Args:
@@ -207,17 +229,17 @@ def C(*args, **kwargs):
 
 @contextmanager
 def admin_db_connection(db_url):
-    url = copy_url(db_url)
+    url = make_url(db_url)
     dbtype = url.get_dialect().name
 
     if dbtype == "postgresql":
-        url.database = ""
+        url = alter_url(url, database='')
 
         if not url.username:
-            url.username = getpass.getuser()
+            url = alter_url(url, username=getpass.getuser())
 
     elif not dbtype == "sqlite":
-        url.database = None
+        url = alter_url(url, database='')
 
     if dbtype == "postgresql":
         with C(url, poolclass=NullPool, isolation_level="AUTOCOMMIT") as c:


### PR DESCRIPTION
A couple small changes required for sqlbag to work with sqlalchemy 1.4:

- `sqlalchemy.engine.url.URL` is now immutable, so had to factor out an `alter_url` method to maintain compatibility with new and old sqla version
- "Unknown thread ID" is now raised as an `OperationalError` instead of an `InternalError` when using pymysql under sqlalchemy 1.4. 