### PR TITLE
Update to SQLAlchemy 2 style

### DIFF
--- a/sampleflaskapp.py
+++ b/sampleflaskapp.py
@@ -1,4 +1,5 @@
 from flask import Flask
+from sqlalchemy import text
 
 from sqlbag.flask import FS, proxies, session_setup
 
@@ -18,7 +19,7 @@ app = get_app()
 @app.route("/")
 def hello():
     # returns 'Hello World!' as a response
-    return s.execute("select 'Hello world!'").scalar()
+    return s.execute(text("select 'Hello world!'")).scalar()
 
 
 if __name__ == "__main__":

--- a/sqlbag/flask/sessions.py
+++ b/sqlbag/flask/sessions.py
@@ -46,7 +46,7 @@ def FS(*args, **kwargs):
 
     and make sure you've called `session_setup` somewhere in your init code also. After that, simply use it in your route methods like so:
 
-    >>> results = s.execute('select a from b')
+    >>> results = s.execute(text('select a from b'))
 
     all usages of this `s` object within the same request will use this same session.
     """

--- a/tests/test_createdrop.py
+++ b/tests/test_createdrop.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+from sqlalchemy import text
+
 from sqlbag import (
     S,
     create_database,
@@ -59,4 +61,4 @@ def test_createdrop(tmpdir):
 
     with temporary_database("sqlite") as dburi:
         with S(dburi) as s:
-            s.execute("select 1")
+            s.execute(text("select 1"))

--- a/tests/test_flask.py
+++ b/tests/test_flask.py
@@ -1,4 +1,5 @@
 from flask import Flask
+from sqlalchemy import text
 
 from common import db  # flake8: noqa
 from sqlbag.flask import FS, session_setup
@@ -12,8 +13,8 @@ def test_flask_integration(db):
 
     @app.route("/")
     def hello():
-        s.execute("select 1")
-        s2.execute("select 2")
+        s.execute(text("select 1"))
+        s2.execute(text("select 2"))
         return "ok"
 
     session_setup(app)

--- a/tests/test_pg.py
+++ b/tests/test_pg.py
@@ -166,26 +166,26 @@ def test_pendulum_for_time_types(db):
                 ts timestamp,
                 tstz timestamptz,
                 d date,
-                t time,
+                ti time,
                 i interval)
         """
         ))
 
         s.execute(text(
             """
-            insert into dt(ts, tstz, d, t, i)
+            insert into dt(ts, tstz, d, ti, i)
             values
             (:ts,
             :tstz,
             :d,
-            :t,
+            :ti,
             :i)
         """),
             {
                 "ts": vanilla(t),
                 "tstz": t.in_timezone("Australia/Sydney"),
                 "d": t.date(),
-                "t": t.time(),
+                "ti": t.time(),
                 "i": i,
             },
         )
@@ -195,7 +195,7 @@ def test_pendulum_for_time_types(db):
         assert out.ts == naive(t.in_tz("UTC"))
         assert out.tstz == t.in_timezone("UTC")
         assert out.d == t.date()
-        assert out.t == t.time()
+        assert out.ti == t.time()
         assert out.i == i
 
         result = s.execute(text(

--- a/tests/test_pg.py
+++ b/tests/test_pg.py
@@ -6,8 +6,10 @@ from datetime import datetime, timedelta, tzinfo
 import pendulum
 from dateutil.relativedelta import relativedelta
 from pytest import raises
+from sqlalchemy import text
 from sqlalchemy.exc import ProgrammingError
 from sqlalchemy.pool import NullPool
+import psycopg2.extensions
 
 from common import db  # flake8: noqa
 from sqlbag import DB_ERROR_TUPLE, S, copy_url, raw_connection
@@ -43,7 +45,7 @@ def test_errors_and_messages(db):
     assert pg_errorname_lookup(22005) == "ERROR_IN_ASSIGNMENT"
 
     with S(db) as s:
-        s.execute("drop table if exists x")
+        s.execute(text("drop table if exists x"))
         assert pg_notices(s) == ['NOTICE:  table "x" does not exist, skipping\n']
         assert pg_notices(s, wipe=True) == [
             'NOTICE:  table "x" does not exist, skipping\n'
@@ -51,7 +53,7 @@ def test_errors_and_messages(db):
         assert pg_notices(s) == []
 
         out = io.StringIO()
-        s.execute("drop table if exists x")
+        s.execute(text("drop table if exists x"))
         pg_print_notices(s, out=out)
 
         assert out.getvalue() == 'NOTICE:  table "x" does not exist, skipping'
@@ -61,11 +63,11 @@ def test_errors_and_messages(db):
 
         assert out.getvalue() == ""
 
-        s.execute("create table x(id text)")
+        s.execute(text("create table x(id text)"))
 
     try:
         with S(db) as s:
-            s.execute("create table x(id text)")
+            s.execute(text("create table x(id text)"))
     except DB_ERROR_TUPLE as e:
         assert errorcode_from_error(e) == "42P07"
 
@@ -158,7 +160,7 @@ def test_pendulum_for_time_types(db):
 
         use_pendulum_for_time_types()
 
-        s.execute(
+        s.execute(text(
             """
             create temporary table dt(
                 ts timestamp,
@@ -167,9 +169,9 @@ def test_pendulum_for_time_types(db):
                 t time,
                 i interval)
         """
-        )
+        ))
 
-        s.execute(
+        s.execute(text(
             """
             insert into dt(ts, tstz, d, t, i)
             values
@@ -178,7 +180,7 @@ def test_pendulum_for_time_types(db):
             :d,
             :t,
             :i)
-        """,
+        """),
             {
                 "ts": vanilla(t),
                 "tstz": t.in_timezone("Australia/Sydney"),
@@ -188,7 +190,7 @@ def test_pendulum_for_time_types(db):
             },
         )
 
-        out = list(s.execute("""select * from dt"""))[0]
+        out = list(s.execute(text("""select * from dt""")))[0]
 
         assert out.ts == naive(t.in_tz("UTC"))
         assert out.tstz == t.in_timezone("UTC")
@@ -196,7 +198,7 @@ def test_pendulum_for_time_types(db):
         assert out.t == t.time()
         assert out.i == i
 
-        result = s.execute(
+        result = s.execute(text(
             """
             select
                 null::timestamp,
@@ -205,7 +207,7 @@ def test_pendulum_for_time_types(db):
                 null::time,
                 null::interval
         """
-        )
+        ))
 
         out = list(result)[0]
         assert list(out) == [None, None, None, None, None]

--- a/tests/test_sqla.py
+++ b/tests/test_sqla.py
@@ -5,7 +5,7 @@ import os
 
 import psycopg2
 from pytest import raises
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, text
 from sqlalchemy.exc import ProgrammingError
 
 from common import db  # flake8: noqa
@@ -59,12 +59,12 @@ def test_basic(db, tmpdir):
     s.close()
 
     with C(url) as c:
-        c.execute("select 1")
+        c.execute(text("select 1"))
         core_to_raw = raw_connection(c)
 
     with raises(ProgrammingError):
         with C(url) as c:
-            c.execute("select bad")
+            c.execute(text("select bad"))
 
     with admin_db_connection("sqlite://") as c:
         pass
@@ -73,7 +73,7 @@ def test_basic(db, tmpdir):
         url = copy_url(mysql_url)
 
         with S(mysql_url) as s:
-            s.execute("select 1")
+            s.execute(text("select 1"))
 
         with admin_db_connection(mysql_url) as c:
             kq = _killquery(url.get_dialect().name, None, True)
@@ -132,6 +132,6 @@ import secrets
 
 def test_transaction_separation(db):
     with S(db) as s1, S(db) as s2:
-        id1 = s1.execute('select txid_current()').fetchall()[0][0]
-        id2 = s2.execute('select txid_current()').fetchall()[0][0]
+        id1 = s1.execute(text('select txid_current()')).fetchall()[0][0]
+        id2 = s2.execute(text('select txid_current()')).fetchall()[0][0]
         assert id1 != id2


### PR DESCRIPTION
- Replace Engine.execute with Connection.execute
- Ensure all raw SQL strings are wrapped in sqlalchemy.text
- Use explicit bound parameter dicts (see https://docs.sqlalchemy.org/en/20/changelog/migration_20.html#execute-method-more-strict-execution-options-are-more-prominent)

`tests/test_pg.py::test_errors_and_messages` is failing for me, but it does so even with sqlbag@master and sqlalchemy 1.3, so not sure what's up there - perhaps a pg or psycopg2 config issue. All other tests are now passing with sqlalchemy 1.3 and 2.0.